### PR TITLE
Use 'flag' package instead of manually parsing arguments

### DIFF
--- a/main.go
+++ b/main.go
@@ -300,14 +300,13 @@ func main() {
 		page := flag.Arg(0)
 		if page == "" {
 			log.Fatal("ERROR: no page provided")
-			os.Exit(1)
 		}
 		printPageForPlatform(*platform, flag.Arg(0))
 	} else {
 		page := flag.Arg(0)
 		if page == "" {
-			log.Fatal("ERROR: no argument provided")
-			os.Exit(1)
+			flag.PrintDefaults()
+			os.Exit(0)
 		}
 		printSinglePage(page)
 	}

--- a/main.go
+++ b/main.go
@@ -25,18 +25,6 @@ const (
 	versionUsage  = "print version and exit"
 )
 
-func printHelp() {
-	fmt.Println("usage: tldr [-v] [OPTION]... SEARCH")
-	fmt.Println()
-	fmt.Println("available commands:")
-	fmt.Println("    -v, --version           print version and exit")
-	fmt.Println("    -h, --help              print this help and exit")
-	fmt.Println("    -u, --update            update local database")
-	fmt.Println("    -p, --platform PLATFORM select platform, supported are linux / osx / sunos / common")
-	fmt.Println("    -a, --list-all          list all available commands for the current platform")
-	fmt.Println("    -r, --render PATH       render a local page for testing purposes")
-}
-
 func printVersion() {
 	fmt.Println("tldr v 0.0.1")
 	fmt.Println("Copyright (C) 2017 Max Strübing")


### PR DESCRIPTION
This PR addresses issue #5. The method used and its flaws are described in [this thread](https://groups.google.com/forum/#!topic/golang-nuts/bkqf4-RDj5Q). Namely, `-v`, `--v`, `-version`, and `--version` are all equivalent, and flags like `-vu` do not work the same as `-v -u`.