### PR TITLE
Issue #6: Let the tool act as a library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ go:
   - 1.8
   - 1.9
 
-script: 
+script:
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
   - make build
-  - go vet main.go
-  - gofmt main.go > diff_file && diff main.go diff_file
+  - go test -v ./...
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMPILE_COMMAND = go build -o bin/tldr main.go
+COMPILE_COMMAND = go build -o bin/tldr cmd/tldr/main.go
 
 # Test command
 TEST = go test
@@ -15,4 +15,4 @@ build: $(SOURCES)
 
 .PHONY: clean
 clean:
-	rm -Rf bin && rm -Rf ~/.cache/tldr
+	rm -Rf bin && rm -Rf ~/.tldr

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -81,7 +81,7 @@ func (r *Repository) Pages(platform string) ([]string, error) {
 // Reload removes the cache directory, recreates it, and saves the data from the remote
 // to the local filesystem.
 func (r *Repository) Reload() error {
-	err := os.Remove(r.directory)
+	err := os.RemoveAll(r.directory)
 	if err != nil {
 		return fmt.Errorf("err removing cache directory: %s", err)
 	}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,145 @@
+package cache
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/user"
+	"path"
+	"time"
+)
+
+const (
+	pagesDirectory = "pages"
+	pageSuffix     = ".md"
+	zipPath        = "/tldr.zip"
+)
+
+// Repository keeps a copy of the data from the remote location on the local
+// filesystem. It implements the tldr.Repository to provide quick access
+// to the requested markdown.
+type Repository struct {
+	directory string
+	remote    string
+	ttl       time.Duration
+}
+
+// NewRepository returns a new cache repository. The data is loaded from the
+// remote if missing or stale.
+func NewRepository(remote string, ttl time.Duration) (*Repository, error) {
+	dir, err := cacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("err getting cache directory: %s", err)
+	}
+
+	repo := &Repository{directory: dir, remote: remote, ttl: ttl}
+
+	info, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		err = repo.makeCacheDir()
+		if err != nil {
+			return nil, fmt.Errorf("err creating cache directory: %s", err)
+		}
+		err = repo.loadFromRemote()
+		if err != nil {
+			return nil, fmt.Errorf("err loading data from remote: %s", err)
+		}
+	} else if err != nil || info.ModTime().Before(time.Now().Add(-ttl)) {
+		err = repo.Reload()
+		if err != nil {
+			return nil, fmt.Errorf("err reloading cache: %s", err)
+		}
+	}
+
+	return repo, nil
+}
+
+// Markdown pulls the markdown from the page in cache.
+func (r *Repository) Markdown(platform, page string) (io.ReadCloser, error) {
+	return os.Open(path.Join(r.directory, pagesDirectory, platform, page+pageSuffix))
+}
+
+// Pages returns all the pages for the given platform.
+func (r *Repository) Pages(platform string) ([]string, error) {
+	dir := path.Join(r.directory, pagesDirectory, platform)
+	pages, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("err reading directory '%s': %s", dir, err)
+	}
+
+	names := make([]string, len(pages))
+	for i, page := range pages {
+		name := page.Name()
+		names[i] = name[:len(name)-3]
+	}
+	return names, nil
+}
+
+// Reload removes the cache directory, recreates it, and saves the data from the remote
+// to the local filesystem.
+func (r *Repository) Reload() error {
+	err := os.Remove(r.directory)
+	if err != nil {
+		return fmt.Errorf("err removing cache directory: %s", err)
+	}
+
+	err = r.makeCacheDir()
+	if err != nil {
+		return fmt.Errorf("err creating cache directory: %s", err)
+	}
+
+	err = r.loadFromRemote()
+	if err != nil {
+		return fmt.Errorf("err loading data from remote: %s", err)
+	}
+	return nil
+}
+
+func (r *Repository) loadFromRemote() error {
+	cache, err := os.Create(r.directory + zipPath)
+	if err != nil {
+		return fmt.Errorf("err creating cache: %s", err)
+	}
+	defer cache.Close()
+
+	resp, err := http.Get(r.remote)
+	if err != nil {
+		return fmt.Errorf("err getting response from remote: %s", err)
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(cache, resp.Body)
+	if err != nil {
+		return fmt.Errorf("err copying response body to cache: %s", err)
+	}
+
+	cmd := exec.Command("unzip", r.directory+zipPath, "-d", r.directory)
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("err unzipping pages: %s", err)
+	}
+
+	err = os.Remove(r.directory + zipPath)
+	if err != nil {
+		return fmt.Errorf("err removing zip: %s", err)
+	}
+	return nil
+}
+
+func (r *Repository) makeCacheDir() error {
+	return os.MkdirAll(r.directory, 0755)
+}
+
+func cacheDir() (string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return "", fmt.Errorf("err getting current user: %s", err)
+	}
+	if usr.HomeDir == "" {
+		return "", fmt.Errorf("err loading current user's home directory")
+	}
+	return path.Join(usr.HomeDir, ".tldr"), nil
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	indexJSON      = "index.json"
 	pagesDirectory = "pages"
 	pageSuffix     = ".md"
 	zipPath        = "/tldr.zip"
@@ -55,6 +56,23 @@ func NewRepository(remote string, ttl time.Duration) (*Repository, error) {
 	}
 
 	return repo, nil
+}
+
+// AvailablePlatforms returns all the availale platforms found in cache.
+func (r *Repository) AvailablePlatforms() ([]string, error) {
+	var platforms []string
+	available, err := ioutil.ReadDir(path.Join(r.directory, pagesDirectory))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range available {
+		platform := f.Name()
+		if platform != indexJSON {
+			platforms = append(platforms, platform)
+		}
+	}
+	return platforms, nil
 }
 
 // Markdown pulls the markdown from the page in cache.

--- a/cmd/tldr/main.go
+++ b/cmd/tldr/main.go
@@ -112,7 +112,21 @@ func main() {
 		platform := tldr.CurrentPlatform()
 		markdown, err := repository.Markdown(platform, page)
 		if err != nil {
-			log.Fatalf("ERROR: getting markdown for '%s/%s': %s", platform, page, err)
+			var platforms []string
+			platforms, err = tldr.AvailablePlatforms(repository)
+			if err != nil {
+				log.Fatalf("ERROR: getting available platforms: %s", err)
+			}
+
+			for _, platform = range platforms {
+				markdown, err = repository.Markdown(platform, page)
+				if err == nil {
+					break
+				}
+			}
+			if err != nil {
+				log.Fatalf("ERROR: getting markdown for '%s': %s", page, err)
+			}
 		}
 		defer markdown.Close()
 

--- a/cmd/tldr/main.go
+++ b/cmd/tldr/main.go
@@ -35,7 +35,7 @@ func printVersion() {
 func main() {
 	repository, err := cache.NewRepository(remoteURL, ttl)
 	if err != nil {
-		log.Fatalf("ERROR: err creating cache repository: %s", err)
+		log.Fatalf("ERROR: creating cache repository: %s", err)
 	}
 
 	version := flag.Bool("version", false, versionUsage)
@@ -59,7 +59,9 @@ func main() {
 		printVersion()
 	} else if *update {
 		err = repository.Reload()
-		log.Fatalf("ERROR: err updating cache: %s", err)
+		if err != nil {
+			log.Fatalf("ERROR: updating cache: %s", err)
+		}
 	} else if *render != "" {
 		if _, err := os.Stat(*render); os.IsNotExist(err) {
 			log.Fatal("ERROR: page doesn't exist")
@@ -67,18 +69,18 @@ func main() {
 
 		page, err := os.Open(*render)
 		if err != nil {
-			log.Fatal("ERROR: err opening the page")
+			log.Fatal("ERROR: opening the page")
 		}
 		defer page.Close()
 
 		err = tldr.Write(page, os.Stdout)
 		if err != nil {
-			log.Fatalf("ERROR: err rendering the page: %s", err)
+			log.Fatalf("ERROR: rendering the page: %s", err)
 		}
 	} else if *listAll {
 		pages, err := repository.Pages(tldr.CurrentPlatform())
 		if err != nil {
-			log.Fatalf("ERROR: err getting pages: %s", err)
+			log.Fatalf("ERROR: getting pages: %s", err)
 		}
 
 		for _, page := range pages {
@@ -92,13 +94,13 @@ func main() {
 
 		markdown, err := repository.Markdown(*platform, page)
 		if err != nil {
-			log.Fatalf("ERROR: err getting markdown for '%s/%s': %s", *platform, page, err)
+			log.Fatalf("ERROR: getting markdown for '%s/%s': %s", *platform, page, err)
 		}
 		defer markdown.Close()
 
 		err = tldr.Write(markdown, os.Stdout)
 		if err != nil {
-			log.Fatalf("ERROR: err writing markdown: %s", err)
+			log.Fatalf("ERROR: writing markdown: %s", err)
 		}
 	} else {
 		page := flag.Arg(0)
@@ -110,13 +112,13 @@ func main() {
 		platform := tldr.CurrentPlatform()
 		markdown, err := repository.Markdown(platform, page)
 		if err != nil {
-			log.Fatalf("ERROR: err getting markdown for '%s/%s': %s", platform, page, err)
+			log.Fatalf("ERROR: getting markdown for '%s/%s': %s", platform, page, err)
 		}
 		defer markdown.Close()
 
 		err = tldr.Write(markdown, os.Stdout)
 		if err != nil {
-			log.Fatalf("ERROR: err writing markdown: %s", err)
+			log.Fatalf("ERROR: writing markdown: %s", err)
 		}
 	}
 }

--- a/cmd/tldr/main.go
+++ b/cmd/tldr/main.go
@@ -2,22 +2,17 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"log"
-	"net/http"
 	"os"
-	"os/exec"
-	"os/user"
-	"path"
-	"runtime"
+	"time"
 
 	"github.com/mstruebing/tldr-go-client"
+	"github.com/mstruebing/tldr-go-client/cache"
 )
 
+// Help message constants
 const (
 	listAllUsage  = "list all available commands for the current platform"
 	platformUsage = "select platform; supported are: linux, osx, sunos, common"
@@ -26,225 +21,21 @@ const (
 	versionUsage  = "print version and exit"
 )
 
+const (
+	remoteURL = "http://tldr-pages.github.io/assets/tldr.zip"
+	ttl       = time.Hour * 24 * 7
+)
+
 func printVersion() {
 	fmt.Println("tldr v 1.0.2")
 	fmt.Println("Copyright (C) 2017 Max Strübing")
 	fmt.Println("Source available at https://github.com")
 }
 
-func downloadFile(filepath string, url string) (err error) {
-	// Create the file
-	out, err := os.Create(filepath)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	// Get the data
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	// Writer the body to file
-	_, err = io.Copy(out, resp.Body)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func fetchPages() {
-	cacheDir := getCacheDir()
-	fmt.Println("fetching pages...")
-	err := downloadFile(cacheDir+"/tldr.zip", "http://tldr-pages.github.io/assets/tldr.zip")
-	if err != nil {
-		log.Fatal(err.Error())
-		log.Fatal("ERROR: Can't fetch tldr repository")
-	}
-}
-
-func unzipPages() {
-	cacheDir := getCacheDir()
-	fmt.Println("unpacking pages...")
-	cmd := exec.Command("unzip", cacheDir+"/tldr.zip", "-d", cacheDir)
-	err := cmd.Run()
-	if err != nil {
-		log.Fatal("ERROR: Can't unzip pages")
-	}
-
-	os.Remove(cacheDir + "/tldr.zip")
-}
-
-func getHomeDirectory() string {
-	usr, err := user.Current()
-	if err != nil {
-		log.Fatal("ERROR: " + err.Error())
-	}
-	if usr.HomeDir == "" {
-		log.Fatal("ERROR: Can't load user's home folder path")
-	}
-
-	return usr.HomeDir
-}
-
-func getCacheDir() string {
-	homeDir := getHomeDirectory()
-	return path.Join(homeDir, ".tldr")
-}
-
-func getPagesDir() string {
-	cacheDir := getCacheDir()
-	return path.Join(cacheDir, "pages")
-}
-
-func createCacheDir() {
-	cacheDir := getCacheDir()
-	os.MkdirAll(cacheDir, 0755)
-}
-
-func removeCacheDir() {
-	cacheDir := getCacheDir()
-	os.RemoveAll(cacheDir)
-}
-
-func setup() {
-	createCacheDir()
-	fetchPages()
-	unzipPages()
-	fmt.Println("All done!")
-}
-
-func updateLocal() {
-	removeCacheDir()
-	setup()
-}
-
-func getCurrentSystem() string {
-	os := runtime.GOOS
-	switch os {
-	case "darwin":
-		os = "osx"
-	}
-
-	return os
-}
-
-func getSystems() []string {
-	var systems []string
-	pagesDir := getPagesDir()
-	currentSystem := getCurrentSystem()
-	systems = append(systems, currentSystem)
-	systems = append(systems, "common")
-
-	availableSystems, err := ioutil.ReadDir(path.Join(pagesDir))
-	if err != nil {
-		log.Fatal("ERROR: Something bad happened while reading directories")
-	}
-
-	for _, availableSystem := range availableSystems {
-		if availableSystem.Name() != "index.json" && availableSystem.Name() != currentSystem && availableSystem.Name() != "common" {
-			systems = append(systems, availableSystem.Name())
-		}
-	}
-
-	return systems
-}
-
-func readLines(path string) ([]string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	var lines []string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
-	}
-	return lines, scanner.Err()
-}
-
-func listAllPages() {
-	currentSystem := getCurrentSystem()
-	pagesDir := getPagesDir()
-	pages, err := ioutil.ReadDir(path.Join(pagesDir, currentSystem))
-	if err != nil {
-		log.Fatal("ERROR: Can't read pages for current platform: " + currentSystem)
-	}
-
-	for _, page := range pages {
-		fmt.Println(page.Name()[:len(page.Name())-3])
-	}
-}
-
-func printPageInPath(path string) {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		log.Fatal("ERROR: Page doesn't exist")
-	}
-	lines, err := os.Open(path)
-	if err != nil {
-		log.Fatal("ERROR: Something went wrong while opening the page")
-	}
-	out, err := tldr.Render(lines)
-	if err != nil {
-		log.Fatalf("ERROR: Something went wrong rendering the page: %s", err)
-	}
-	fmt.Print(out)
-}
-
-func printPageForPlatform(platform string, page string) {
-	pagesDir := getPagesDir()
-	platformDir := path.Join(pagesDir, platform)
-	file := platformDir + "/" + page + ".md"
-	if _, err := os.Stat(file); os.IsNotExist(err) {
-		log.Fatal("ERROR: no page found for " + page + " in platform " + platform)
-	}
-
-	lines, err := os.Open(file)
-	if err != nil {
-		log.Fatal("ERROR: Something went wrong while opening the page")
-	}
-	out, err := tldr.Render(lines)
-	if err != nil {
-		log.Fatalf("ERROR: Something went wrong rendering the page: %s", err)
-	}
-	fmt.Print(out)
-}
-
-func printSinglePage(page string) {
-	pagesDir := getPagesDir()
-	systems := getSystems()
-
-	for index, system := range systems {
-		systemDir := path.Join(pagesDir, system)
-		file := systemDir + "/" + page + ".md"
-		if _, err := os.Stat(file); os.IsNotExist(err) {
-			if index == 1 {
-				log.Fatal("ERROR: no page found for " + page)
-			}
-		} else {
-			lines, err := os.Open(file)
-			if err != nil {
-				log.Fatal("ERROR: Something went wrong while opening the page")
-			}
-			out, err := tldr.Render(lines)
-			if err != nil {
-				log.Fatalf("ERROR: Something went wrong rendering the page: %s", err)
-			}
-			fmt.Print(out)
-			break
-		}
-	}
-}
-
 func main() {
-	pagesDir := getPagesDir()
-	if _, err := os.Stat(pagesDir); os.IsNotExist(err) {
-		updateLocal()
+	repository, err := cache.NewRepository(remoteURL, ttl)
+	if err != nil {
+		log.Fatalf("ERROR: err creating cache repository: %s", err)
 	}
 
 	version := flag.Bool("version", false, versionUsage)
@@ -267,23 +58,65 @@ func main() {
 	if *version {
 		printVersion()
 	} else if *update {
-		updateLocal()
+		err = repository.Reload()
+		log.Fatalf("ERROR: err updating cache: %s", err)
 	} else if *render != "" {
-		printPageInPath(*render)
+		if _, err := os.Stat(*render); os.IsNotExist(err) {
+			log.Fatal("ERROR: page doesn't exist")
+		}
+
+		page, err := os.Open(*render)
+		if err != nil {
+			log.Fatal("ERROR: err opening the page")
+		}
+		defer page.Close()
+
+		err = tldr.Write(page, os.Stdout)
+		if err != nil {
+			log.Fatalf("ERROR: err rendering the page: %s", err)
+		}
 	} else if *listAll {
-		listAllPages()
+		pages, err := repository.Pages(tldr.CurrentPlatform())
+		if err != nil {
+			log.Fatalf("ERROR: err getting pages: %s", err)
+		}
+
+		for _, page := range pages {
+			fmt.Println(page)
+		}
 	} else if *platform != "" {
 		page := flag.Arg(0)
 		if page == "" {
 			log.Fatal("ERROR: no page provided")
 		}
-		printPageForPlatform(*platform, flag.Arg(0))
+
+		markdown, err := repository.Markdown(*platform, page)
+		if err != nil {
+			log.Fatalf("ERROR: err getting markdown for '%s/%s': %s", *platform, page, err)
+		}
+		defer markdown.Close()
+
+		err = tldr.Write(markdown, os.Stdout)
+		if err != nil {
+			log.Fatalf("ERROR: err writing markdown: %s", err)
+		}
 	} else {
 		page := flag.Arg(0)
 		if page == "" {
 			flag.PrintDefaults()
 			os.Exit(0)
 		}
-		printSinglePage(page)
+
+		platform := tldr.CurrentPlatform()
+		markdown, err := repository.Markdown(platform, page)
+		if err != nil {
+			log.Fatalf("ERROR: err getting markdown for '%s/%s': %s", platform, page, err)
+		}
+		defer markdown.Close()
+
+		err = tldr.Write(markdown, os.Stdout)
+		if err != nil {
+			log.Fatalf("ERROR: err writing markdown: %s", err)
+		}
 	}
 }

--- a/platform.go
+++ b/platform.go
@@ -1,0 +1,14 @@
+package tldr
+
+import (
+	"runtime"
+)
+
+// CurrentPlatform returns the platform name of the current system.
+func CurrentPlatform() string {
+	os := runtime.GOOS
+	if os == "darwin" {
+		os = "osx"
+	}
+	return os
+}

--- a/platform.go
+++ b/platform.go
@@ -4,6 +4,9 @@ import (
 	"runtime"
 )
 
+// CommonPlatform is the common platform.
+const CommonPlatform = "common"
+
 // CurrentPlatform returns the platform name of the current system.
 func CurrentPlatform() string {
 	os := runtime.GOOS
@@ -11,4 +14,30 @@ func CurrentPlatform() string {
 		os = "osx"
 	}
 	return os
+}
+
+// AvailablePlatforms returns all the available platforms that are supported.
+func AvailablePlatforms(r Repository) ([]string, error) {
+	platforms, err := r.AvailablePlatforms()
+	if err != nil {
+		return nil, err
+	}
+
+	current := CurrentPlatform()
+	var currentFound, commonFound bool
+	for _, p := range platforms {
+		if p == current {
+			currentFound = true
+		} else if p == CommonPlatform {
+			commonFound = true
+		}
+	}
+
+	if !currentFound {
+		platforms = append(platforms, CurrentPlatform())
+	}
+	if !commonFound {
+		platforms = append(platforms, CommonPlatform)
+	}
+	return platforms, nil
 }

--- a/render.go
+++ b/render.go
@@ -1,0 +1,45 @@
+package tldr
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+const (
+	BLUE  = "\x1b[34;1m"
+	GREEN = "\x1b[32;1m"
+	RED   = "\x1b[31;1m"
+	RESET = "\x1b[30;1m"
+)
+
+func Render(markdown io.Reader) (string, error) {
+	var rendered string
+	scanner := bufio.NewScanner(markdown)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") {
+			// Heading
+			rendered += line[2:] + "\n"
+		} else if strings.HasPrefix(line, ">") {
+			// Quote
+			rendered += line[2:] + "\n"
+		} else if strings.HasPrefix(line, "-") {
+			// List
+			rendered += GREEN + line + RESET + "\n"
+			// rendered += "\t" + RED + convertExample()
+			// fmt.Printf("    %s%s%s\n", RED, convertExample(lines[i+2]), RESET)
+			// if i < len(lines)-3 {
+			// 	fmt.Println()
+			// }
+		} else if strings.HasPrefix(line, "`") {
+			// Code
+			line = strings.Replace(line, "{{", BLUE, -1)
+			line = strings.Replace(line, "}}", RED, -1)
+			rendered += "\t" + strings.Trim(line, "`") + RESET + "\n"
+		} else {
+			rendered += line + "\n"
+		}
+	}
+	return rendered, scanner.Err()
+}

--- a/render.go
+++ b/render.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// Output terms
 const (
 	BLUE  = "\x1b[34;1m"
 	GREEN = "\x1b[32;1m"
@@ -13,33 +14,47 @@ const (
 	RESET = "\x1b[30;1m"
 )
 
+// Render takes the given input and renders it for a prettier output.
 func Render(markdown io.Reader) (string, error) {
 	var rendered string
+	var renderingExample bool
 	scanner := bufio.NewScanner(markdown)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "#") {
+		if renderingExample {
+			// Skip the empty line
+			scanner.Scan()
+			line = scanner.Text()
+
+			line = strings.Replace(line, "{{", BLUE, -1)
+			line = strings.Replace(line, "}}", RED, -1)
+			rendered += "\t" + RED + strings.Trim(line, "`") + RESET + "\n"
+
+			renderingExample = false
+		} else if strings.HasPrefix(line, "#") {
 			// Heading
 			rendered += line[2:] + "\n"
 		} else if strings.HasPrefix(line, ">") {
 			// Quote
 			rendered += line[2:] + "\n"
 		} else if strings.HasPrefix(line, "-") {
-			// List
+			// Example
 			rendered += GREEN + line + RESET + "\n"
-			// rendered += "\t" + RED + convertExample()
-			// fmt.Printf("    %s%s%s\n", RED, convertExample(lines[i+2]), RESET)
-			// if i < len(lines)-3 {
-			// 	fmt.Println()
-			// }
-		} else if strings.HasPrefix(line, "`") {
-			// Code
-			line = strings.Replace(line, "{{", BLUE, -1)
-			line = strings.Replace(line, "}}", RED, -1)
-			rendered += "\t" + strings.Trim(line, "`") + RESET + "\n"
+			renderingExample = true
 		} else {
 			rendered += line + "\n"
 		}
 	}
 	return rendered, scanner.Err()
+}
+
+// Write is a convenience function that calls Render and writes the output
+// to the destination.
+func Write(markdown io.Reader, dest io.Writer) error {
+	out, err := Render(markdown)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(dest, out)
+	return err
 }

--- a/repository.go
+++ b/repository.go
@@ -1,0 +1,8 @@
+package tldr
+
+import "io"
+
+type Repository interface {
+	Markdown(platform, page string) (io.ReadCloser, error)
+	Pages(platform string) ([]string, error)
+}

--- a/repository.go
+++ b/repository.go
@@ -2,7 +2,9 @@ package tldr
 
 import "io"
 
+// Repository is used to abstract where the pages are stored.
 type Repository interface {
+	AvailablePlatforms() ([]string, error)
 	Markdown(platform, page string) (io.ReadCloser, error)
 	Pages(platform string) ([]string, error)
 }


### PR DESCRIPTION
This PR addresses issue #6. The repository is structured more like a library, with the main file in a `cmd` folder.